### PR TITLE
Add kms_key_id setting for cloudtrail

### DIFF
--- a/cloudtrail.tf
+++ b/cloudtrail.tf
@@ -16,6 +16,7 @@ resource "aws_cloudtrail" "cloudtrail" {
   enable_log_file_validation    = "${var.enable_log_file_validation}"
   is_multi_region_trail         = "${var.is_multi_region_trail}"
   event_selector                = "${var.event_selector}"
+  kms_key_id                    = "${var.kms_key_id}"
 
   tags = "${var.tags}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -134,6 +134,11 @@ variable "monitor_readonly_user_name" {
   default     = "monitor_readonly"
 }
 
+variable "kms_key_id" {
+  description = "The arn of the CMK key which is used for encrypting cloudtrail logs"
+  default     = ""
+}
+
 ### AWS Config
 variable "aws_config_notification_emails" {
   description = "A list of email addresses for that will receive AWS Config changes notifications"


### PR DESCRIPTION
At Kabisa we prefer to use CMK keys as much as possible, so also for our Cloudtrail logs. 
For that reason, I've added this (optional) option, which makes it possible to use your own CMK key for cloudtrail in this module.