### PR TITLE
In the latest AWS provider, you cannot set the region on an S3 bucket, so this parameter is invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ module "account_setup" {
 
   # Cloudtrail (optional)
   enable_cloudtrail        = true
-  cloudtrail_bucket_region = "eu-west-1"
   trail_name               = "my-account-trail"
 
   # Creates read only group (optional)
@@ -55,7 +54,6 @@ module "account_setup" {
 | allow_users_to_change_password | Whether to allow users to change their own password | string | `true` | no |
 | aws_config_notification_emails | A list of email addresses for that will receive AWS Config changes notifications | list | `<list>` | no |
 | cloudtrail_bucket | The name of the cloudtrail bucket | string | `` | no |
-| cloudtrail_bucket_region | The region where the cloudtrail bucket will be created or is located, required if cloudtrail is enabled | string | `` | no |
 | enable_account_password_policy | Enable custom (strict) password policy. | string | `true` | no |
 | enable_admin_group | Create an admin group. | string | `true` | no |
 | enable_aws_config | Specifies if the AWS Config should be enabled | string | `false` | no |

--- a/cloudtrail.tf
+++ b/cloudtrail.tf
@@ -52,7 +52,6 @@ resource "aws_s3_bucket" "cloudtrail_bucket" {
 
   bucket        = local.bucket_name
   force_destroy = true
-  region        = var.cloudtrail_bucket_region
 
   tags = var.tags
 

--- a/examples/cloudtrail-with-data-events/main.tf
+++ b/examples/cloudtrail-with-data-events/main.tf
@@ -12,7 +12,6 @@ module "account_setup" {
 
   # Cloudtrail (optional)
   enable_cloudtrail        = true
-  cloudtrail_bucket_region = "eu-west-1"
   trail_name               = "my-account-trail"
 
   # Configure Data events below example 

--- a/examples/cloudtrail/main.tf
+++ b/examples/cloudtrail/main.tf
@@ -12,6 +12,5 @@ module "account_setup" {
 
   # Cloudtrail (optional)
   enable_cloudtrail        = true
-  cloudtrail_bucket_region = "eu-west-1"
   trail_name               = "my-account-trail"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -75,12 +75,6 @@ variable "read_only_group_name" {
 
 ### CLOUDTRAIL
 
-variable "cloudtrail_bucket_region" {
-  type        = string
-  description = "The region where the cloudtrail bucket will be created or is located, required if cloudtrail is enabled"
-  default     = ""
-}
-
 variable "cloudtrail_bucket" {
   type        = string
   description = "The name of the cloudtrail bucket"


### PR DESCRIPTION
Using latest version of the AWS terraform provider (3.18), the cloudtrail s3 bucket configuration is no longer valid.

Specifically, the `region` is now an output parameter only, not a variable. I have raised this PR so I can continue using this module against the latest version of the AWS terraform provider.

Terraform Plan Output:
```
$ terraform plan
Error: Computed attribute cannot be set

  on .terraform/modules/account_setup/cloudtrail.tf line 55, in resource "aws_s3_bucket" "cloudtrail_bucket":
  55:   region        = var.cloudtrail_bucket_region
```

Example Module:
```module "account_setup" {
  source = "philips-software/account-setup/aws"
  version = "~> 2.0.0"

  enable_mfa                     = false
  enable_account_password_policy = false
  minimum_password_length        = 8
  max_password_age               = 36500 // 100 years

  enable_read_only_group = true
}```

